### PR TITLE
Target java 1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ scalaVersion := "2.10.4"
 
 scalacOptions += "-target:jvm-1.7"
 
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+
 resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
 
 parallelExecution in Test := false


### PR DESCRIPTION
I think the artifact you're publishing is still java 1.8. I tweaked the build settings and confirmed them using javap.

```
$ javap -verbose -classpath target/scala-2.10/akka-persistence-kafka_2.10-0.4-SNAPSHOT.jar  akka/persistence/kafka/snapshot/SnapshotMetadataFormat$SnapshotMetadata | grep major
  major version: 51
```
