### PR TITLE
Watch ZK for broker updates and react accordingly

### DIFF
--- a/src/main/scala/akka/persistence/kafka/BrokerWatcher.scala
+++ b/src/main/scala/akka/persistence/kafka/BrokerWatcher.scala
@@ -1,0 +1,40 @@
+
+package akka.persistence.kafka
+
+import akka.actor.ActorRef
+import akka.persistence.kafka.BrokerWatcher.BrokersUpdated
+import akka.persistence.kafka.MetadataConsumer.Broker
+import kafka.utils.{ZkUtils, ZKStringSerializer, ZKConfig}
+import org.I0Itec.zkclient.ZkClient
+
+object BrokerWatcher {
+
+  case class BrokersUpdated(brokers: List[Broker])
+
+}
+
+class BrokerWatcher(zkConfig: ZKConfig, listener: ActorRef) {
+
+  lazy val zkClient = new ZkClient(
+    zkConfig.zkConnect,
+    zkConfig.zkSessionTimeoutMs,
+    zkConfig.zkConnectionTimeoutMs,
+    ZKStringSerializer)
+
+  lazy val childWatcher = new ChildDataWatcher[String](zkClient, ZkUtils.BrokerIdsPath, { d =>
+    listener ! BrokersUpdated(buildBrokers(d))
+  })
+
+  def start(): List[Broker] = {
+    buildBrokers(childWatcher.start())
+  }
+
+  def stop(): Unit = {
+    childWatcher.stop()
+    zkClient.close()
+  }
+
+  private def buildBrokers(d: Map[String, String]): List[Broker] = {
+    d.values.map(Broker.fromString).flatMap(x => x).toList
+  }
+}

--- a/src/main/scala/akka/persistence/kafka/ChildDataWatcher.scala
+++ b/src/main/scala/akka/persistence/kafka/ChildDataWatcher.scala
@@ -1,0 +1,90 @@
+package akka.persistence.kafka
+
+import java.util
+
+import org.I0Itec.zkclient.exception.ZkNoNodeException
+import org.I0Itec.zkclient.{IZkDataListener, ZkClient, IZkChildListener}
+
+private [kafka] class ChildDataWatcher[T](
+  zkClient: ZkClient,
+  path: String,
+  cb: (Map[String, T]) => Unit)
+  extends IZkChildListener
+  with IZkDataListener {
+
+  import scala.collection.JavaConverters._
+
+  private var childDataMap = Map[String, T]()
+
+  def start(): Map[String, T] = {
+    val eventLock = zkClient.getEventLock
+    try {
+      eventLock.lock()
+      val children = zkClient.subscribeChildChanges(path, this)
+      if (children != null) {
+        handleChildChange(path, children, invokeCallback = false)
+      }
+      childDataMap
+    } finally {
+      eventLock.unlock()
+    }
+  }
+
+  def stop(): Unit = {
+    val eventLock = zkClient.getEventLock
+    try {
+      eventLock.lock()
+      zkClient.unsubscribeChildChanges(path, this)
+      childDataMap.foreach {
+        case (c, _) => zkClient.unsubscribeDataChanges(childPath(c), this)
+      }
+    } finally {
+      eventLock.unlock()
+    }
+  }
+
+  def handleChildChange(parentPath: String, currentChilds: util.List[String]): Unit = {
+    handleChildChange(parentPath, currentChilds, invokeCallback = true)
+  }
+
+  def handleChildChange(parentPath: String, currentChilds: util.List[String], invokeCallback: Boolean): Unit = {
+    val oldChildren = childDataMap.keySet
+    // WARNING: if the currentChilds is null we can treat it as an empty set, however, we are never going to be notified
+    // if the parentPath is re-created.
+    val newChildren = if (currentChilds != null) currentChilds.asScala.toSet else Set.empty[String]
+    val childrenAdded = newChildren.diff(oldChildren)
+    val childrenRemoved = oldChildren.diff(newChildren)
+
+    childrenRemoved.foreach { c =>
+      zkClient.unsubscribeDataChanges(childPath(c), this)
+      childDataMap = childDataMap - c
+    }
+
+    childrenAdded.foreach { c =>
+      zkClient.subscribeDataChanges(childPath(c), this)
+      try {
+        val data = zkClient.readData[T](childPath(c))
+        childDataMap = childDataMap + (c -> data)
+      } catch {
+        case e: ZkNoNodeException =>
+          zkClient.unsubscribeDataChanges(childPath(c), this)
+      }
+    }
+
+    if (invokeCallback)
+      cb(childDataMap)
+  }
+
+  def handleDataChange(path: String, data: Object): Unit = {
+    childDataMap = childDataMap + (childId(path) -> data.asInstanceOf[T])
+    cb(childDataMap)
+  }
+
+  def handleDataDeleted(path: String): Unit = {
+    // znode deletion is handled by handleChildChange
+  }
+
+  private def childId(path: String): String = path.substring(this.path.size + 1)
+
+  private def childPath(child: String): String = path + "/" + child
+}

--- a/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
+++ b/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
@@ -16,6 +16,7 @@ import akka.pattern.ask
 import akka.persistence.PersistentRepr
 import akka.persistence.kafka._
 import akka.persistence.kafka.MetadataConsumer.Broker
+import akka.persistence.kafka.BrokerWatcher.BrokersUpdated
 import akka.util.Timeout
 
 class KafkaJournal extends AsyncWriteJournal with MetadataConsumer {
@@ -25,16 +26,33 @@ class KafkaJournal extends AsyncWriteJournal with MetadataConsumer {
 
   val serialization = SerializationExtension(context.system)
   val config = new KafkaJournalConfig(context.system.settings.config.getConfig("kafka-journal"))
-  val brokers = allBrokers()
+
+  val brokerWatcher = new BrokerWatcher(config.zookeeperConfig, self)
+  var brokers = brokerWatcher.start()
+
+  override def postStop(): Unit = {
+    brokerWatcher.stop()
+    super.postStop()
+  }
+
+  override def receive: Receive = localReceive.orElse(super.receive)
+
+  private def localReceive: Receive = {
+    case BrokersUpdated(newBrokers) if newBrokers != brokers =>
+      brokers = newBrokers
+      journalProducerConfig = config.journalProducerConfig(brokers)
+      eventProducerConfig = config.eventProducerConfig(brokers)
+      writers.foreach(_ ! UpdateKafkaJournalWriterConfig(writerConfig))
+  }
 
   // --------------------------------------------------------------------------------------
   //  Journal writes
   // --------------------------------------------------------------------------------------
 
-  val journalProducerConfig = config.journalProducerConfig(brokers)
-  val eventProducerConfig = config.eventProducerConfig(brokers)
+  var journalProducerConfig = config.journalProducerConfig(brokers)
+  var eventProducerConfig = config.eventProducerConfig(brokers)
 
-  val writers: Vector[ActorRef] = Vector.fill(config.writeConcurrency)(writer())
+  var writers: Vector[ActorRef] = Vector.fill(config.writeConcurrency)(writer())
   val writeTimeout = Timeout(journalProducerConfig.requestTimeoutMs.millis)
 
   // Transient deletions only to pass TCK (persistent not supported)
@@ -69,9 +87,13 @@ class KafkaJournal extends AsyncWriteJournal with MetadataConsumer {
     writers(math.abs(persistenceId.hashCode) % config.writeConcurrency)
 
   private def writer(): ActorRef = {
-    def writerConfig = KafkaJournalWriterConfig(journalProducerConfig, eventProducerConfig, config.eventTopicMapper, serialization)
     context.actorOf(Props(new KafkaJournalWriter(writerConfig)).withDispatcher(config.pluginDispatcher))
   }
+
+  private def writerConfig = {
+    KafkaJournalWriterConfig(journalProducerConfig, eventProducerConfig, config.eventTopicMapper, serialization)
+  }
+
 
   // --------------------------------------------------------------------------------------
   //  Journal reads
@@ -123,12 +145,20 @@ private case class KafkaJournalWriterConfig(
   evtTopicMapper: EventTopicMapper,
   serialization: Serialization)
 
-private class KafkaJournalWriter(config: KafkaJournalWriterConfig) extends Actor {
-  import config._
-  val msgProducer = new Producer[String, Array[Byte]](config.journalProducerConfig)
-  val evtProducer = new Producer[String, Event](config.eventProducerConfig)
+private case class UpdateKafkaJournalWriterConfig(config: KafkaJournalWriterConfig)
+
+private class KafkaJournalWriter(var config: KafkaJournalWriterConfig) extends Actor {
+  var msgProducer = createMessageProducer()
+  var evtProducer = createEventProducer()
 
   def receive = {
+    case UpdateKafkaJournalWriterConfig(newConfig) =>
+      msgProducer.close()
+      evtProducer.close()
+      config = newConfig
+      msgProducer = createMessageProducer()
+      evtProducer = createEventProducer()
+
     case messages: Seq[PersistentRepr] =>
       writeMessages(messages)
       sender ! ()
@@ -137,12 +167,12 @@ private class KafkaJournalWriter(config: KafkaJournalWriterConfig) extends Actor
   def writeMessages(messages: Seq[PersistentRepr]): Unit = {
     val keyedMsgs = for {
       m <- messages
-    } yield new KeyedMessage[String, Array[Byte]](journalTopic(m.persistenceId), "static", serialization.serialize(m).get)
+    } yield new KeyedMessage[String, Array[Byte]](journalTopic(m.persistenceId), "static", config.serialization.serialize(m).get)
 
     val keyedEvents = for {
       m <- messages
       e = Event(m.persistenceId, m.sequenceNr, m.payload)
-      t <- evtTopicMapper.topicsFor(e)
+      t <- config.evtTopicMapper.topicsFor(e)
     } yield new KeyedMessage(t, e.persistenceId, e)
 
     msgProducer.send(keyedMsgs: _*)
@@ -154,4 +184,8 @@ private class KafkaJournalWriter(config: KafkaJournalWriterConfig) extends Actor
     evtProducer.close()
     super.postStop()
   }
+
+  private def createMessageProducer() = new Producer[String, Array[Byte]](config.journalProducerConfig)
+
+  private def createEventProducer() = new Producer[String, Event](config.eventProducerConfig)
 }

--- a/src/main/scala/akka/persistence/kafka/server/TestServer.scala
+++ b/src/main/scala/akka/persistence/kafka/server/TestServer.scala
@@ -55,7 +55,11 @@ class TestKafkaServer(config: TestServerConfig) {
   private val server: KafkaServer =
     new KafkaServer(config.kafka)
 
-  server.startup()
+  start()
+
+  def start(): Unit = {
+    server.startup()
+  }
 
   def stop(): Unit = {
     server.shutdown()

--- a/src/test/scala/akka/persistence/kafka/BrokerWatcherSpec.scala
+++ b/src/test/scala/akka/persistence/kafka/BrokerWatcherSpec.scala
@@ -1,0 +1,149 @@
+package akka.persistence.kafka
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.persistence.kafka.BrokerWatcher.BrokersUpdated
+import akka.persistence.kafka.MetadataConsumer.Broker
+import akka.persistence.kafka.server.{TestKafkaServer, TestServerConfig, TestZookeeperServer}
+import akka.testkit.{ImplicitSender, TestKit}
+import com.typesafe.config.{ConfigValueFactory, ConfigFactory}
+import kafka.utils.{VerifiableProperties, ZKConfig}
+import org.apache.commons.io.FileUtils
+import org.scalatest.{BeforeAndAfterEach, BeforeAndAfterAll, Matchers, WordSpecLike}
+
+object BrokerWatcherSpec {
+
+  val dataDir = "target/test"
+
+  val config = ConfigFactory.parseString(
+   s"""
+      |akka.persistence.journal.plugin = "kafka-journal"
+      |akka.persistence.snapshot-store.plugin = "kafka-snapshot-store"
+      |akka.test.single-expect-default = 10s
+      |kafka-journal.event.producer.request.required.acks = 1
+      |kafka-journal.zookeeper.connection.timeout.ms = 10000
+      |kafka-journal.zookeeper.session.timeout.ms = 10000
+      |test-server.zookeeper.dir = "$dataDir/zookeeper"
+    """.stripMargin).withFallback(ConfigFactory.load("reference"))
+
+  val zkClientConfig = new ZKConfig(new VerifiableProperties(configToProperties(ConfigFactory.parseString(
+   s"""
+      |zookeeper.connect = "localhost:${config.getInt("test-server.zookeeper.port")}"
+      |zookeeper.session.timeout.ms = 6000
+      |zookeeper.connection.timeout.ms = 6000
+      |zookeeper.sync.time.ms = 2000
+    """.stripMargin))))
+
+  val basePort = 6667
+
+}
+
+abstract class BrokerWatcherSpec
+  extends TestKit(ActorSystem("test", BrokerWatcherSpec.config))
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  import BrokerWatcherSpec._
+
+  FileUtils.deleteDirectory(new File(dataDir))
+  val zookeeper = new TestZookeeperServer(new TestServerConfig(config.getConfig("test-server")))
+
+  override def afterAll(): Unit = {
+    zookeeper.stop()
+    super.afterAll()
+  }
+
+  def spawnKafka(brokerId: Int): TestKafkaServer = {
+    new TestKafkaServer(new TestServerConfig(config.getConfig("test-server")
+      .withValue("kafka.broker.id", ConfigValueFactory.fromAnyRef(brokerId))
+      .withValue("kafka.port", ConfigValueFactory.fromAnyRef(basePort + (brokerId - 1)))
+      .withValue("kafka.log.dirs", ConfigValueFactory.fromAnyRef(dataDir + "/" + s"kafka-$brokerId"))))
+  }
+
+  def withWatcher(body: BrokerWatcher => Unit) = {
+    val watcher = new BrokerWatcher(zkClientConfig, testActor)
+    try {
+      body(watcher)
+    } finally {
+      watcher.stop()
+    }
+  }
+
+  def withKafka(brokerId: Int)(body: TestKafkaServer => Unit) = {
+    val kafka = spawnKafka(brokerId)
+    try {
+      body(kafka)
+    } finally {
+      kafka.stop()
+    }
+  }
+
+  def expectBrokers(r: Range): Unit = {
+    val msg = expectMsgClass(classOf[BrokersUpdated])
+    assertBrokers(msg.brokers, r)
+  }
+
+  def assertBrokers(brokers: List[Broker], r: Range): Unit = {
+    assert(brokers.toSet === r.map(id => Broker("localhost", basePort + (id - 1))).toSet)
+  }
+
+}
+
+class BrokerWatcherSpecWithKafkas extends BrokerWatcherSpec {
+
+  val kafkas = (1 to 3).map(id =>
+    spawnKafka(id)
+  )
+
+  override def afterAll(): Unit = {
+    kafkas.foreach(_.stop())
+    super.afterAll()
+  }
+
+  "A BrokerWatcher" must {
+    "return current list of brokers on start" in {
+      withWatcher { watcher =>
+        val brokers = watcher.start()
+        assertBrokers(brokers, 1 to 3)
+      }
+    }
+
+    "notify listener when brokers are added and removed" in {
+      withWatcher { watcher =>
+        watcher.start()
+        withKafka(4) { newBroker =>
+          expectBrokers(1 to 4)
+          kafkas(0).stop()
+          expectBrokers(2 to 4)
+        }
+      }
+    }
+  }
+
+}
+
+class BrokerWatcherSpecWithoutKafkas extends BrokerWatcherSpec {
+
+  "A BrokerWatcher" must {
+    "return an empty list if no brokers are available on start" in {
+      withWatcher { watcher =>
+        val brokers = watcher.start()
+        assert(brokers === List.empty[Broker])
+      }
+    }
+    "notify listener when brokers eventually become available" in {
+      withWatcher { watcher =>
+        val brokers = watcher.start()
+        assert(brokers === List.empty[Broker])
+        withKafka(0) { newBroker =>
+          expectBrokers(0 until 0)
+          expectBrokers(0 until 1)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
@krasserm 

This PR attempts to address https://github.com/krasserm/akka-persistence-kafka/issues/14. It keeps the same start up behaviour as before, i.e, read the /broker/ids directory synchronously.
1. Watch the /brokers/ids directory (and children) for changes
2. When changes occur, update the journal actor configuration and respawn the writer actors
3. When changes occur, update the snapshot actor configuration
