### PR TITLE
ISSUE-16 : Upgrade to support cross build for 2.10 and 2.11, bump .travi...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
   - "2.10.4"
+  - "2.11.2"
 jdk:
   - oraclejdk8
   - openjdk7

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,9 @@ name := "akka-persistence-kafka"
 
 version := "0.4-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.2"
+
+crossScalaVersions := Seq("2.10.4", "2.11.0")
 
 scalacOptions += "-target:jvm-1.7"
 
@@ -20,7 +22,7 @@ libraryDependencies ++= Seq(
   //
   "com.typesafe.akka" %% "akka-persistence-experimental" % "2.3.6",
   "org.apache.curator" % "curator-test" % "2.5.0",
-  "org.apache.kafka"  %% "kafka" % "0.8.1.1",
+  "org.apache.kafka"  %% "kafka" % "0.8.2-beta",
   //
   // Test dependencies
   //


### PR DESCRIPTION
- Upgraded build to do a cross compile build supporting 2.10.x and 2.11.x versions.
- Update kafka artifact to version 0.8.2-beta
- .travis.yml changed to support 2.11.2
