### PR TITLE
Transactional producers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 scala:
-  - "2.10.4"
-  - "2.11.2"
+  - "2.11.6"
 jdk:
   - oraclejdk8
   - openjdk7

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The following [broker configurations](http://kafka.apache.org/documentation.html
 
 - `num.partitions` should be set to `1` by default because the plugins only write to partition 0 of [journal topics](#journal-topics) and [snapshot topics](#snapshot-topics). If a higher number of partitions is needed for [user-defined topics](#user-defined-topics) (e.g. for scalability or throughput reasons) then this should be configured manually with the `kafka-topics` command line tool. 
 - `default.replication.factor` should be set to at least `2` for high-availability of topics created by the plugins.
-- `message.max.bytes` and `replica.fetch.max.bytes` should be set to a value that is larger than the largest snapshot size. The default value is `1024 * 1024` which may be large enough for journal entries but likely to small for snapshots. When changing these settings make sure to also set `kafka-snapshot-store.consumer.fetch.message.max.bytes` and `kafka-journal.consumer.fetch.message.max.bytes` to this value.     
+- `message.max.bytes` and `replica.fetch.max.bytes` should be set to a value that is larger than the largest snapshot size. The default value is `1024 * 1024` which may be large enough for journal entries but likely too small for snapshots. When changing these settings make sure to also set `kafka-snapshot-store.consumer.fetch.message.max.bytes` and `kafka-journal.consumer.fetch.message.max.bytes` to this value.     
 - `log.cleanup.policy` must be set to `"compact"` otherwise the most recent snapshot may be deleted if the retention time is exceeded and complete state recovery of persistent actors is not possible any more.  
 
 See also section [Usage hints](#usage-hints).

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"   %% "akka-persistence-experimental" % "2.3.11",
   "com.github.krasserm" %% "akka-persistence-testkit"      % "0.3.4"    % Test,
   "commons-io"           % "commons-io"                    % "2.4"      % Test,
-  "org.apache.kafka"    %% "kafka"                         % "0.8.2.1",
+  "org.apache.kafka"    %% "kafka"                         % "0.11.0.1",
   "org.apache.curator"   % "curator-test"                  % "2.7.1"    % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.16

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -63,22 +63,11 @@ kafka-journal {
     # No need to set it here.
     # -------------------------------------------------------------------
 
-    request.required.acks = 1
-
-    # DO NOT CHANGE!
-    producer.type = "sync"
-
     # DO NOT CHANGE!
     partitioner.class = "akka.persistence.kafka.StickyPartitioner"
 
     # DO NOT CHANGE!
     key.serializer.class = "kafka.serializer.StringEncoder"
-
-    # Increase if hundreds of topics are created during initialization.
-    message.send.max.retries = 5
-
-    # Increase if hundreds of topics are created during initialization.
-    retry.backoff.ms = 100
 
     # Add further Kafka producer settings here, if needed.
     # ...
@@ -90,8 +79,6 @@ kafka-journal {
     #
     # See http://kafka.apache.org/documentation.html#producerconfigs
     # -------------------------------------------------------------------
-
-    producer.type = "sync"
 
     request.required.acks = 0
 
@@ -236,5 +223,11 @@ test-server {
     log.dirs = data/kafka
 
     log.index.size.max.bytes = 1024
+
+    transaction.state.log.replication.factor = 1
+    transaction.state.log.min.isr = 1
+    offsets.topic.replication.factor = 1
+
+    min.insync.replicas = 1
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -51,6 +51,8 @@ kafka-journal {
     socket.receive.buffer.bytes = 65536
 
     fetch.message.max.bytes = 1048576
+
+    isolation.level = read_committed
   }
 
   producer {
@@ -144,11 +146,13 @@ kafka-snapshot-store {
     # See http://kafka.apache.org/documentation.html#simpleconsumerapi
     # -------------------------------------------------------------------
 
-    socket.timeout.ms = 30000
+    request.timeout.ms = 30000
 
-    socket.receive.buffer.bytes = 65536
+    receive.buffer.bytes = 65536
 
-    fetch.message.max.bytes = 1048576
+    fetch.max.bytes = 1048576
+
+    isolation.level = read_committed
   }
 
   producer {
@@ -163,13 +167,8 @@ kafka-snapshot-store {
 
     request.required.acks = 1
 
-    producer.type = "sync"
-
     # DO NOT CHANGE!
     partitioner.class = "akka.persistence.kafka.StickyPartitioner"
-
-    # DO NOT CHANGE!
-    key.serializer.class = "kafka.serializer.StringEncoder"
 
     # Increase if hundreds of topics are created during initialization.
     message.send.max.retries = 5

--- a/src/main/scala/akka/persistence/kafka/BrokerWatcher.scala
+++ b/src/main/scala/akka/persistence/kafka/BrokerWatcher.scala
@@ -15,11 +15,7 @@ object BrokerWatcher {
 
 class BrokerWatcher(zkConfig: ZKConfig, listener: ActorRef) {
 
-  lazy val zkClient = new ZkClient(
-    zkConfig.zkConnect,
-    zkConfig.zkSessionTimeoutMs,
-    zkConfig.zkConnectionTimeoutMs,
-    ZKStringSerializer)
+  lazy val zkClient = ZkUtils.createZkClient(zkConfig.zkConnect, zkConfig.zkSessionTimeoutMs, zkConfig.zkConnectionTimeoutMs)
 
   lazy val childWatcher = new ChildDataWatcher[String](zkClient, ZkUtils.BrokerIdsPath, { d =>
     listener ! BrokersUpdated(buildBrokers(d))

--- a/src/main/scala/akka/persistence/kafka/MessageIterator.scala
+++ b/src/main/scala/akka/persistence/kafka/MessageIterator.scala
@@ -4,6 +4,7 @@ import kafka.api.FetchRequestBuilder
 import kafka.common.ErrorMapping
 import kafka.consumer._
 import kafka.message._
+import org.apache.kafka.common.protocol.Errors
 
 object MessageUtil {
   def payloadBytes(m: Message): Array[Byte] = {
@@ -28,9 +29,9 @@ class MessageIterator(host: String, port: Int, topic: String, partition: Int, of
     val request = new FetchRequestBuilder().addFetch(topic, partition, offset, fetchMessageMaxBytes).build()
     val response = consumer.fetch(request)
 
-    response.errorCode(topic, partition) match {
-      case NoError => response.messageSet(topic, partition).iterator
-      case anError => throw exceptionFor(anError)
+    response.error(topic, partition) match {
+      case Errors.NONE => response.messageSet(topic, partition).iterator
+      case anError => throw exceptionFor(anError.code())
     }
   }
 

--- a/src/main/scala/akka/persistence/kafka/MetadataConsumer.scala
+++ b/src/main/scala/akka/persistence/kafka/MetadataConsumer.scala
@@ -1,13 +1,12 @@
 package akka.persistence.kafka
 
 import scala.util._
-
 import kafka.api._
 import kafka.common._
 import kafka.consumer._
 import kafka.utils._
-
 import org.I0Itec.zkclient.ZkClient
+import org.apache.kafka.common.protocol.Errors
 
 object MetadataConsumer {
   object Broker {
@@ -57,10 +56,10 @@ trait MetadataConsumer {
     val topicMetadata = response.topicsMetadata(0)
 
     try {
-      topicMetadata.errorCode match {
-        case LeaderNotAvailableCode => None
-        case NoError => topicMetadata.partitionsMetadata.filter(_.partitionId == config.partition)(0).leader.map(leader => Broker(leader.host, leader.port))
-        case anError => throw exceptionFor(anError)
+      topicMetadata.error match {
+        case Errors.LEADER_NOT_AVAILABLE => None
+        case Errors.NONE => topicMetadata.partitionsMetadata.filter(_.partitionId == config.partition)(0).leader.map(leader => Broker(leader.host, leader.port))
+        case anError => throw exceptionFor(anError.code)
       }
     } finally {
       consumer.close()
@@ -78,8 +77,8 @@ trait MetadataConsumer {
 
     try {
       offsetPartitionResponse.error match {
-        case NoError => offsetPartitionResponse.offsets.head
-        case anError => throw exceptionFor(anError)
+        case Errors.NONE => offsetPartitionResponse.offsets.head
+        case anError => throw exceptionFor(anError.code)
       }
     } finally {
       consumer.close()

--- a/src/main/scala/akka/persistence/kafka/MetadataConsumer.scala
+++ b/src/main/scala/akka/persistence/kafka/MetadataConsumer.scala
@@ -78,7 +78,8 @@ trait MetadataConsumer {
       val topicPartition = new TopicPartition(topic, partition)
       consumer.assign(Seq(topicPartition).asJava)
       consumer.seekToEnd(Seq(topicPartition).asJava)
-      consumer.position(topicPartition) - 1
+      val nextPosition = consumer.position(topicPartition)
+      if (nextPosition <= 0) nextPosition else nextPosition - 1
     } finally {
       consumer.close()
     }

--- a/src/main/scala/akka/persistence/kafka/MetadataConsumerConfig.scala
+++ b/src/main/scala/akka/persistence/kafka/MetadataConsumerConfig.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.Config
 import kafka.consumer.ConsumerConfig
 import kafka.utils._
 
-class MetadataConsumerConfig(config: Config) {
+class MetadataConsumerConfig(val config: Config) {
   val partition: Int =
     config.getInt("partition")
 

--- a/src/main/scala/akka/persistence/kafka/StickyPartitioner.scala
+++ b/src/main/scala/akka/persistence/kafka/StickyPartitioner.scala
@@ -1,9 +1,18 @@
 package akka.persistence.kafka
 
-import kafka.producer.Partitioner
-import kafka.utils.VerifiableProperties
+import java.util
 
-class StickyPartitioner(props: VerifiableProperties) extends Partitioner {
-  val partition = props.getInt("partition")
-  def partition(key: Any, numPartitions: Int): Int = partition
+import org.apache.kafka.clients.producer.Partitioner
+import org.apache.kafka.common.Cluster
+
+class StickyPartitioner() extends Partitioner {
+  var partition: Option[Int] = None
+
+  override def partition(topic: String, key: scala.Any, keyBytes: Array[Byte], value: scala.Any, valueBytes: Array[Byte], cluster: Cluster) = partition.get
+
+  override def configure(configs: util.Map[String, _]) = {
+    partition = Some(configs.get("partition").asInstanceOf[String].toInt)
+  }
+
+  override def close() = {}
 }

--- a/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
+++ b/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
@@ -190,7 +190,7 @@ private class KafkaJournalWriter(var config: KafkaJournalWriterConfig, val index
         throw e
     }
 
-    producerRecords.foreach { record =>
+    keyedEvents.foreach { record =>
       val javaFuture = evtProducer.send(record)
       javaFuture.get()
     }

--- a/src/main/scala/akka/persistence/kafka/journal/KafkaJournalConfig.scala
+++ b/src/main/scala/akka/persistence/kafka/journal/KafkaJournalConfig.scala
@@ -1,6 +1,6 @@
 package akka.persistence.kafka.journal
 
-import java.util.Properties
+import java.util.{Properties, UUID}
 
 import akka.persistence.kafka._
 import akka.persistence.kafka.MetadataConsumer.Broker
@@ -20,9 +20,13 @@ class KafkaJournalConfig(config: Config) extends MetadataConsumerConfig(config) 
 
   def journalProducerConfig(brokers: List[Broker]): Properties =
     configToProperties(config.getConfig("producer"),
-      Map("metadata.broker.list" -> Broker.toString(brokers), "partition" -> config.getString("partition")))
+      Map(
+        "bootstrap.servers" -> Broker.toString(brokers),
+        "partition" -> config.getString("partition"),
+        "transactional.id" -> UUID.randomUUID().toString
+      ))
 
   def eventProducerConfig(brokers: List[Broker]): Properties =
     configToProperties(config.getConfig("event.producer"),
-      Map("metadata.broker.list" -> Broker.toString(brokers)))
+      Map("bootstrap.servers" -> Broker.toString(brokers)))
 }

--- a/src/main/scala/akka/persistence/kafka/journal/KafkaJournalConfig.scala
+++ b/src/main/scala/akka/persistence/kafka/journal/KafkaJournalConfig.scala
@@ -1,12 +1,12 @@
 package akka.persistence.kafka.journal
 
+import java.util.Properties
+
 import akka.persistence.kafka._
 import akka.persistence.kafka.MetadataConsumer.Broker
-
 import com.typesafe.config.Config
-
-import kafka.producer.ProducerConfig
 import kafka.utils._
+import org.apache.kafka.clients.producer.ProducerConfig
 
 class KafkaJournalConfig(config: Config) extends MetadataConsumerConfig(config) {
   val pluginDispatcher: String =
@@ -16,13 +16,13 @@ class KafkaJournalConfig(config: Config) extends MetadataConsumerConfig(config) 
     config.getInt("write-concurrency")
 
   val eventTopicMapper: EventTopicMapper =
-    Utils.createObject[EventTopicMapper](config.getString("event.producer.topic.mapper.class"))
+    CoreUtils.createObject[EventTopicMapper](config.getString("event.producer.topic.mapper.class"))
 
-  def journalProducerConfig(brokers: List[Broker]): ProducerConfig =
-    new ProducerConfig(configToProperties(config.getConfig("producer"),
-      Map("metadata.broker.list" -> Broker.toString(brokers), "partition" -> config.getString("partition"))))
+  def journalProducerConfig(brokers: List[Broker]): Properties =
+    configToProperties(config.getConfig("producer"),
+      Map("metadata.broker.list" -> Broker.toString(brokers), "partition" -> config.getString("partition")))
 
-  def eventProducerConfig(brokers: List[Broker]): ProducerConfig =
-    new ProducerConfig(configToProperties(config.getConfig("event.producer"),
-      Map("metadata.broker.list" -> Broker.toString(brokers))))
+  def eventProducerConfig(brokers: List[Broker]): Properties =
+    configToProperties(config.getConfig("event.producer"),
+      Map("metadata.broker.list" -> Broker.toString(brokers)))
 }

--- a/src/main/scala/akka/persistence/kafka/snapshot/KafkaSnapshotStoreConfig.scala
+++ b/src/main/scala/akka/persistence/kafka/snapshot/KafkaSnapshotStoreConfig.scala
@@ -1,10 +1,10 @@
 package akka.persistence.kafka.snapshot
 
+import java.util.{Properties, UUID}
+
 import akka.persistence.kafka._
 import akka.persistence.kafka.MetadataConsumer.Broker
-
 import com.typesafe.config.Config
-
 import kafka.producer.ProducerConfig
 
 class KafkaSnapshotStoreConfig(config: Config) extends MetadataConsumerConfig(config) {
@@ -14,7 +14,11 @@ class KafkaSnapshotStoreConfig(config: Config) extends MetadataConsumerConfig(co
   val ignoreOrphan: Boolean =
     config.getBoolean("ignore-orphan")
 
-  def producerConfig(brokers: List[Broker]): ProducerConfig =
-    new ProducerConfig(configToProperties(config.getConfig("producer"),
-      Map("metadata.broker.list" -> Broker.toString(brokers), "partition" -> config.getString("partition"))))
+  def producerConfig(brokers: List[Broker]): Properties =
+    configToProperties(config.getConfig("producer"),
+      Map(
+        "bootstrap.servers" -> Broker.toString(brokers),
+        "partition" -> config.getString("partition"),
+        "transactional.id" -> UUID.randomUUID().toString
+      ))
 }

--- a/src/test/scala/akka/persistence/kafka/integration/KafkaIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/kafka/integration/KafkaIntegrationSpec.scala
@@ -139,8 +139,8 @@ class KafkaIntegrationSpec extends TestKit(ActorSystem("test", KafkaIntegrationS
       "ignore orphan snapshots (snapshot sequence nr > highest journal sequence nr)" in {
         val persistenceId = "pa"
 
-        store ! SaveSnapshot(SnapshotMetadata(persistenceId, 4), "test")
-        expectMsgPF() { case SaveSnapshotSuccess(md) => md.sequenceNr should be(4L) }
+        store ! SaveSnapshot(SnapshotMetadata(persistenceId, 7), "test")
+        expectMsgPF() { case SaveSnapshotSuccess(md) => md.sequenceNr should be(7L) }
 
         withPersistentActor(persistenceId) { _ =>
           expectMsg("a-1")
@@ -154,8 +154,8 @@ class KafkaIntegrationSpec extends TestKit(ActorSystem("test", KafkaIntegrationS
         store ! SaveSnapshot(SnapshotMetadata(persistenceId, 2), "test")
         expectMsgPF() { case SaveSnapshotSuccess(md) => md.sequenceNr should be(2L) }
 
-        store ! SaveSnapshot(SnapshotMetadata(persistenceId, 4), "test")
-        expectMsgPF() { case SaveSnapshotSuccess(md) => md.sequenceNr should be(4L) }
+        store ! SaveSnapshot(SnapshotMetadata(persistenceId, 7), "test")
+        expectMsgPF() { case SaveSnapshotSuccess(md) => md.sequenceNr should be(7L) }
 
         withPersistentActor(persistenceId) { _ =>
           expectMsgPF() { case SnapshotOffer(SnapshotMetadata(_, snr, _), _) => snr should be(2) }

--- a/src/test/scala/akka/persistence/kafka/snapshot/KafkaSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/kafka/snapshot/KafkaSnapshotStoreSpec.scala
@@ -16,7 +16,8 @@ class KafkaSnapshotStoreSpec extends SnapshotStoreSpec with KafkaCleanup {
       |akka.persistence.journal.plugin = "kafka-journal"
       |akka.persistence.snapshot-store.plugin = "kafka-snapshot-store"
       |akka.test.single-expect-default = 10s
-      |kafka-snapshot-store.consumer.fetch.message.max.bytes = ${maxMessageSize}
+      |kafka-snapshot-store.consumer.fetch.max.bytes = ${maxMessageSize}
+      |kafka-snapshot-store.producer.max.request.size = ${maxMessageSize}
       |kafka-snapshot-store.ignore-orphan = false
       |test-server.kafka.message.max.bytes = ${maxMessageSize}
       |test-server.kafka.replica.fetch.max.bytes = ${maxMessageSize}


### PR DESCRIPTION
This is an early version with kafka 0.11 support and transactional producers implemented, as described in #20. I would welcome some early feedback.

While this version works and passes the tests, I think some additional work should still be done:

- Replace all uses of the old scala kafka api with the new java producers and consumers
- Remove the dependency on kafka, and only depend on kafka-clients?
- Can the dependency on zookeeper and the BrokerWatcher mechanism be removed?
- Upgrade to the latest version of akka-persistence (not experimental anymore)
- Don't use multiple KafkaProducer instances in the KafkaJournalWriters (From the KafkaProducer javadoc: `The producer is thread safe and sharing a single producer instance across threads will generally be faster than having multiple instances.`)
- Add tests for transactional behaviour by mocking the kafka producer?
- Update the README
